### PR TITLE
Add gem "wdm" for Windows platforms to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,8 @@ gem "middleman", "~> 3.1.3"
 # Compass plugins
 gem 'susy', "~> 1.0.9" # Susy
 gem 'compass-h5bp', "~> 0.1.1" # HTML5 Boilerplate styles
+
+### Windows specific gems ###
+platforms :mswin, :mingw do
+   gem "wdm", "~> 0.1.0" # Windows Directory Monitor 
+end


### PR DESCRIPTION
Tested for Windows 7-64 ruby 1.9.3p448 (2013-06-27) [i386-mingw32]
